### PR TITLE
Retain LOFTEE-flagged variants as HC

### DIFF
--- a/scripts/get_gnomad_lof_variants.py
+++ b/scripts/get_gnomad_lof_variants.py
@@ -149,7 +149,6 @@ def get_gnomad_lof_variants(gnomad_version, gene_ids, include_low_confidence=Fal
                 gene_ids.contains(csq.gene_id)
                 & csq.consequence_terms.any(lambda term: PLOF_CONSEQUENCE_TERMS.contains(term))
                 & (include_low_confidence | (csq.lof == "HC"))
-                & (include_low_confidence | (hl.is_missing(csq.lof_flags)))
             )
         )
     )


### PR DESCRIPTION
As per the discussion in Slack, variants with a LOFTEE flag will be retained as "high-confidence" so they can still be assessed during manual curation.