### PR TITLE
Downgrade node back to 16 on deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #########################
 # Build front end       #
 #########################
-FROM node:lts-alpine
+FROM node:16-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
LTS is a floating tag, and it was upgraded at some point. 16 was likely the last working version.