### PR TITLE
Db migrate workflow

### DIFF
--- a/.github/workflows/deploy_prod.yaml
+++ b/.github/workflows/deploy_prod.yaml
@@ -6,71 +6,8 @@ on:
       - main
 
 jobs:
-  migrate_database:
-    runs-on: ubuntu-latest
-
-    env:
-      CLOUDSDK_CORE_DISABLE_PROMPTS: 1
-
-    steps:
-      - name: "checkout repo"
-        uses: actions/checkout@v2
-
-      - name: "setup Python"
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.9
-
-      - name: "use pip cache"
-        uses: actions/cache@v1
-        with:
-          path: ~/.cache/pip
-          key: pip-${{ hashFiles('**/requirements*.txt') }}
-          restore-keys: |
-            pip-
-
-      - name: "install dependencies"
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt -r requirements-dev.txt
-
-      - name: "authenticate google cloud"
-        id: "auth"
-        uses: "google-github-actions/auth@v1"
-        with:
-          service_account: ${{ secrets.GCP_DEPLOY_KEY }}
-
-      - name: "gcloud setup"
-        uses: google-github-actions/setup-gcloud@v1
-        with:
-          project_id: curator-348003
-          install_components: "cloud_sql_proxy"
-
-      - name: "gcloud secrets"
-        id: "secrets"
-        uses: "google-github-actions/get-secretmanager-secrets@v1"
-        with:
-          secrets: |-
-            secret_key:curator-348003/django-secret-key-prod/latest
-            db_password:curator-348003/postgres-password-prod/latest
-
-      - name: "apply database migrations"
-        env:
-          DJANGO_SETTINGS_MODULE: curation_portal.settings.base
-          DB_ENGINE: django.db.backends.postgresql
-          DB_HOST: localhost
-          DB_PORT: 5432
-          DB_DATABASE: curator-prod
-          DB_USER: curator-prod
-          DB_PASSWORD: "${{ steps.secrets.outputs.db_password }}"
-          SECRET_KEY: "${{ steps.secrets.outputs.secret_key }}"
-        run: |
-          ./cloud-sql-proxy \
-            --port 5432 curator-348003:australia-southeast1:curator-postgres &
-            python manage.py migrate
-
-  deploy_server:
-    runs-on: ubuntu-latest
+  build:
+   runs-on: ubuntu-latest 
 
     env:
       DOCKER_BUILDKIT: 1
@@ -81,16 +18,80 @@ jobs:
       - name: "checkout repo"
         uses: actions/checkout@v2
 
-      - name: "authenticate google cloud"
-        id: "auth"
-        uses: "google-github-actions/auth@v1"
-        with:
-          service_account: ${{ secrets.GCP_DEPLOY_KEY }}
-
       - name: "gcloud setup"
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: curator-348003
+          service_account_key: ${{ secrets.GCP_DEPLOY_KEY }}
+
+      - name: 'gcloud docker auth'
+        run: |
+          gcloud auth configure-docker australia-southeast1-docker.pkg.dev
+
+      - name: "set short SHA"
+        id: repo
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+   
+      - name: 'build image'
+        run: |
+          docker build -t australia-southeast1-docker.pkg.dev/curator-348003/images/curator-prod:${{ steps.repo.outputs.short_sha }} . --no-cache
+      
+      - name: 'push image'
+        run: |
+          docker push $DOCKER_IMAGE
+
+  migrate:
+    runs-on: ubuntu-latest
+
+    env:
+      CLOUDSDK_CORE_DISABLE_PROMPTS: 1
+
+    steps:
+      - name: "checkout repo"
+        uses: actions/checkout@v2
+
+      - name: "gcloud setup"
+        uses: google-github-actions/setup-gcloud@v0
+        with:
+          project_id: curator-348003
+          service_account_key: ${{ secrets.GCP_DEPLOY_KEY }}
+
+      - name: "set short SHA"
+        id: repo
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: "build and deploy"
+        run: |
+          gcloud beta run jobs create \
+            curator-prod-migrate-db \
+            --region=australia-southeast1 \
+            --image=australia-southeast1-docker.pkg.dev/curator-348003/images/curator-prod:${{ steps.repo.outputs.short_sha }} \
+            --service-account=curator-prod@curator-348003.iam.gserviceaccount.com \
+            --set-cloudsql-instances=curator-348003:australia-southeast1:curator-postgres \
+            --set-env-vars=DJANGO_SETTINGS_MODULE=curation_portal.settings.base,DB_ENGINE=django.db.backends.postgresql,DB_HOST=/cloudsql/curator-348003:australia-southeast1:curator-postgres,DB_DATABASE=curator-prod,DB_USER=curator-prod \
+            --set-secrets=SECRET_KEY=django-secret-key-prod:latest,DB_PASSWORD=postgres-password-prod:latest \
+            --command="python manage.py migrate" \
+            --execute-now
+
+  deploy:
+    runs-on: ubuntu-latest
+
+    env:
+      CLOUDSDK_CORE_DISABLE_PROMPTS: 1
+
+    steps:
+      - name: "checkout repo"
+        uses: actions/checkout@v2
+
+      - name: "gcloud setup"
+        uses: google-github-actions/setup-gcloud@v0
+        with:
+          project_id: curator-348003
+          service_account_key: ${{ secrets.GCP_DEPLOY_KEY }}
+
+      - name: "set short SHA"
+        id: repo
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: "build and deploy"
         run: |
@@ -100,7 +101,7 @@ jobs:
             --service-account=curator-prod@curator-348003.iam.gserviceaccount.com \
             --no-allow-unauthenticated \
             --add-cloudsql-instances=curator-348003:australia-southeast1:curator-postgres \
-            --source=. \
+            --image=australia-southeast1-docker.pkg.dev/curator-348003/images/curator-prod:${{ steps.repo.outputs.short_sha }} \
             --port=8000 \
             --set-env-vars=DJANGO_SETTINGS_MODULE=curation_portal.settings.base,ALLOWED_HOSTS=curator.populationgenomics.org.au,CURATION_PORTAL_AUTH_HEADER=HTTP_X_GOOG_AUTHENTICATED_USER_EMAIL,DB_ENGINE=django.db.backends.postgresql,DB_HOST=/cloudsql/curator-348003:australia-southeast1:curator-postgres,DB_DATABASE=curator-prod,DB_USER=curator-prod \
             --update-secrets=SECRET_KEY=django-secret-key-prod:latest,DB_PASSWORD=postgres-password-prod:latest \

--- a/.github/workflows/deploy_prod.yaml
+++ b/.github/workflows/deploy_prod.yaml
@@ -6,6 +6,66 @@ on:
       - main
 
 jobs:
+  migrate_database:
+    runs-on: ubuntu-latest
+
+    env:
+      CLOUDSDK_CORE_DISABLE_PROMPTS: 1
+
+    steps:
+      - name: "checkout repo"
+        uses: actions/checkout@v2
+
+      - name: "setup Python"
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: "use pip cache"
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            pip-
+
+      - name: "install dependencies"
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: "install Cloud SQL Proxy"
+        run: |
+          wget https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 -O cloud_sql_proxy
+          chmod +x cloud_sql_proxy
+
+      - name: "gcloud setup"
+        id: "auth"
+        uses: google-github-actions/setup-gcloud@v0
+        with:
+          project_id: curator-348003
+          service_account_key: ${{ secrets.GCP_DEPLOY_KEY }}
+
+      - name: "gcloud secrets"
+        id: "secrets"
+        uses: "google-github-actions/get-secretmanager-secrets@v1"
+        with:
+          secrets: |-
+            secret_key:curator-348003/django-secret-key-prod/latest
+            db_password:curator-348003/postgres-password-prod/latest
+
+      - name: "apply database migrations"
+        env:
+          DJANGO_SETTINGS_MODULE: curation_portal.settings.base
+          DB_ENGINE: django.db.backends.postgresql
+          DB_HOST: /cloudsql/curator-348003:australia-southeast1:curator-postgres
+          DB_DATABASE: curator-prod
+          DB_USER: curator-prod
+          DB_PASSWORD: "${{ steps.secrets.outputs.db_password }}"
+          SECRET_KEY: "${{ steps.secrets.outputs.secret_key }}"
+        run: |
+          python manage.py migrate
+
   deploy_server:
     runs-on: ubuntu-latest
 
@@ -15,25 +75,25 @@ jobs:
       CLOUDSDK_CORE_DISABLE_PROMPTS: 1
 
     steps:
-    - name: "checkout repo"
-      uses: actions/checkout@v2
+      - name: "checkout repo"
+        uses: actions/checkout@v2
 
-    - name: "gcloud setup"
-      uses: google-github-actions/setup-gcloud@v0
-      with:
-        project_id: curator-348003
-        service_account_key: ${{ secrets.GCP_DEPLOY_KEY }}
+      - name: "gcloud setup"
+        uses: google-github-actions/setup-gcloud@v0
+        with:
+          project_id: curator-348003
+          service_account_key: ${{ secrets.GCP_DEPLOY_KEY }}
 
-    - name: "build and deploy"
-      run: |
-        gcloud run deploy \
-          --project=curator-348003 \
-          --region=australia-southeast1 \
-          --service-account=curator-prod@curator-348003.iam.gserviceaccount.com \
-          --no-allow-unauthenticated \
-          --add-cloudsql-instances=curator-348003:australia-southeast1:curator-postgres \
-          --source=. \
-          --port=8000 \
-          --set-env-vars=DJANGO_SETTINGS_MODULE=curation_portal.settings.base,ALLOWED_HOSTS=curator.populationgenomics.org.au,CURATION_PORTAL_AUTH_HEADER=HTTP_X_GOOG_AUTHENTICATED_USER_EMAIL,DB_ENGINE=django.db.backends.postgresql,DB_HOST=/cloudsql/curator-348003:australia-southeast1:curator-postgres,DB_DATABASE=curator-prod,DB_USER=curator-prod \
-          --update-secrets=SECRET_KEY=django-secret-key-prod:latest,DB_PASSWORD=postgres-password-prod:latest \
-          curator-prod
+      - name: "build and deploy"
+        run: |
+          gcloud run deploy \
+            --project=curator-348003 \
+            --region=australia-southeast1 \
+            --service-account=curator-prod@curator-348003.iam.gserviceaccount.com \
+            --no-allow-unauthenticated \
+            --add-cloudsql-instances=curator-348003:australia-southeast1:curator-postgres \
+            --source=. \
+            --port=8000 \
+            --set-env-vars=DJANGO_SETTINGS_MODULE=curation_portal.settings.base,ALLOWED_HOSTS=curator.populationgenomics.org.au,CURATION_PORTAL_AUTH_HEADER=HTTP_X_GOOG_AUTHENTICATED_USER_EMAIL,DB_ENGINE=django.db.backends.postgresql,DB_HOST=/cloudsql/curator-348003:australia-southeast1:curator-postgres,DB_DATABASE=curator-prod,DB_USER=curator-prod \
+            --update-secrets=SECRET_KEY=django-secret-key-prod:latest,DB_PASSWORD=postgres-password-prod:latest \
+            curator-prod

--- a/.github/workflows/deploy_prod.yaml
+++ b/.github/workflows/deploy_prod.yaml
@@ -1,18 +1,22 @@
-name: Deploy to prod
+name: Deploy
 
 on:
   push:
     branches:
       - main
+      - dev
 
 jobs:
-  build:
-   runs-on: ubuntu-latest 
+  build_and_deploy:
+    runs-on: ubuntu-latest
 
     env:
       DOCKER_BUILDKIT: 1
       BUILDKIT_PROGRESS: plain
       CLOUDSDK_CORE_DISABLE_PROMPTS: 1
+      PROJECT_ID: curator-348003
+      REGION_ID: australia-southeast1
+      DB_ENGINE: django.db.backends.postgresql
 
     steps:
       - name: "checkout repo"
@@ -21,88 +25,75 @@ jobs:
       - name: "gcloud setup"
         uses: google-github-actions/setup-gcloud@v0
         with:
-          project_id: curator-348003
+          project_id: ${{ PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_DEPLOY_KEY }}
 
-      - name: 'gcloud docker auth'
+      - name: "set deployment info"
+        id: "deploy_info"
         run: |
-          gcloud auth configure-docker australia-southeast1-docker.pkg.dev
+          SHA=$(git rev-parse --short HEAD)
 
-      - name: "set short SHA"
-        id: repo
-        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-   
-      - name: 'build image'
+          if [[ "${{ github.ref_name }}" == "main" ]];
+          then
+            TYPE=prod
+            echo "django_settings_module=curation_portal.settings.base" >> $GITHUB_OUTPUT
+            echo "cloud_sql_id=curator-348003:australia-southeast1:curator-postgres" >> $GITHUB_OUTPUT
+          else
+            TYPE=${{ github.ref_name }}
+            echo "django_settings_module=curation_portal.settings.$TYPE" >> $GITHUB_OUTPUT
+            echo "cloud_sql_id=curator-348003:australia-southeast1:curator-postgres-$TYPE" >> $GITHUB_OUTPUT
+          fi
+
+          if grep -q "curator-$TYPE-migrate-db" "$(gcloud beta run jobs list)";
+          then
+            SUB_COMMAND=update
+          else
+            SUB_COMMAND=create
+          fi
+
+          echo "job_command=$SUB_COMMAND" >> $GITHUB_OUTPUT
+          echo "type=$TYPE" >> $GITHUB_OUTPUT
+          echo "db_user=curator-$TYPE" >> $GITHUB_OUTPUT
+          echo "db_database=curator-$TYPE" >> $GITHUB_OUTPUT
+          echo "service_account=curator-$TYPE@curator-348003.iam.gserviceaccount.com" >> $GITHUB_OUTPUT
+          echo "image_tag=$REGION_ID-docker.pkg.dev/$PROJECT_ID/images/curator-$TYPE:$SHA" >> $GITHUB_OUTPUT
+
+      - name: "gcloud docker auth"
         run: |
-          docker build -t australia-southeast1-docker.pkg.dev/curator-348003/images/curator-prod:${{ steps.repo.outputs.short_sha }} . --no-cache
-      
-      - name: 'push image'
+          gcloud auth configure-docker $REGION_ID-docker.pkg.dev
+
+      - name: "build image"
         run: |
-          docker push $DOCKER_IMAGE
+          docker build -t ${{ steps.deploy_info.outputs.image_tag }} . --no-cache
 
-  migrate:
-    runs-on: ubuntu-latest
-
-    env:
-      CLOUDSDK_CORE_DISABLE_PROMPTS: 1
-
-    steps:
-      - name: "checkout repo"
-        uses: actions/checkout@v2
-
-      - name: "gcloud setup"
-        uses: google-github-actions/setup-gcloud@v0
-        with:
-          project_id: curator-348003
-          service_account_key: ${{ secrets.GCP_DEPLOY_KEY }}
-
-      - name: "set short SHA"
-        id: repo
-        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-
-      - name: "build and deploy"
+      - name: "push image"
         run: |
-          gcloud beta run jobs create \
-            curator-prod-migrate-db \
-            --region=australia-southeast1 \
-            --image=australia-southeast1-docker.pkg.dev/curator-348003/images/curator-prod:${{ steps.repo.outputs.short_sha }} \
-            --service-account=curator-prod@curator-348003.iam.gserviceaccount.com \
-            --set-cloudsql-instances=curator-348003:australia-southeast1:curator-postgres \
-            --set-env-vars=DJANGO_SETTINGS_MODULE=curation_portal.settings.base,DB_ENGINE=django.db.backends.postgresql,DB_HOST=/cloudsql/curator-348003:australia-southeast1:curator-postgres,DB_DATABASE=curator-prod,DB_USER=curator-prod \
-            --set-secrets=SECRET_KEY=django-secret-key-prod:latest,DB_PASSWORD=postgres-password-prod:latest \
-            --command="python manage.py migrate" \
-            --execute-now
+          docker push ${{ steps.deploy_info.outputs.image_tag }}
 
-  deploy:
-    runs-on: ubuntu-latest
+      - name: "run migrations"
+        run: |
+          gcloud beta run jobs ${{ steps.deploy_info.outputs.job_command }} \
+            curator-${{ steps.deploy_info.outputs.type }}-migrate-db \
+            --region=$REGION_ID \
+            --image=${{ steps.deploy_info.outputs.image_tag }} \
+            --service-account=${{ steps.deploy_info.outputs.service_account }} \
+            --set-cloudsql-instances=${{ steps.deploy_info.outputs.cloud_sql_id }} \
+            --set-env-vars=DJANGO_SETTINGS_MODULE=${{ steps.deploy_info.outputs.django_settings_module }},DB_ENGINE=$DB_ENGINE,DB_HOST=/cloudsql/${{ steps.deploy_info.outputs.cloud_sql_id }},DB_DATABASE=${{ steps.deploy_info.outputs.db_database }},DB_USER=${{ steps.deploy_info.outputs.db_user }} \
+            --set-secrets=SECRET_KEY=django-secret-key-${{ steps.deploy_info.outputs.type }}:latest,DB_PASSWORD=postgres-password-${{ steps.deploy_info.outputs.type }}:latest \
+            --command='python,manage.py,migrate' \
+            --execute-now \
+            --wait
 
-    env:
-      CLOUDSDK_CORE_DISABLE_PROMPTS: 1
-
-    steps:
-      - name: "checkout repo"
-        uses: actions/checkout@v2
-
-      - name: "gcloud setup"
-        uses: google-github-actions/setup-gcloud@v0
-        with:
-          project_id: curator-348003
-          service_account_key: ${{ secrets.GCP_DEPLOY_KEY }}
-
-      - name: "set short SHA"
-        id: repo
-        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-
-      - name: "build and deploy"
+      - name: "deploy"
         run: |
           gcloud run deploy \
-            --project=curator-348003 \
-            --region=australia-southeast1 \
-            --service-account=curator-prod@curator-348003.iam.gserviceaccount.com \
+            curator-${{ steps.deploy_info.outputs.type }} \
+            --project=$PROJECT_ID \
+            --region=$REGION_ID \
+            --service-account=${{ steps.deploy_info.outputs.service_account }} \
             --no-allow-unauthenticated \
-            --add-cloudsql-instances=curator-348003:australia-southeast1:curator-postgres \
-            --image=australia-southeast1-docker.pkg.dev/curator-348003/images/curator-prod:${{ steps.repo.outputs.short_sha }} \
+            --add-cloudsql-instances=${{ steps.deploy_info.outputs.cloud_sql_id }} \
+            --image=${{ steps.deploy_info.outputs.image_tag }} \
             --port=8000 \
-            --set-env-vars=DJANGO_SETTINGS_MODULE=curation_portal.settings.base,ALLOWED_HOSTS=curator.populationgenomics.org.au,CURATION_PORTAL_AUTH_HEADER=HTTP_X_GOOG_AUTHENTICATED_USER_EMAIL,DB_ENGINE=django.db.backends.postgresql,DB_HOST=/cloudsql/curator-348003:australia-southeast1:curator-postgres,DB_DATABASE=curator-prod,DB_USER=curator-prod \
-            --update-secrets=SECRET_KEY=django-secret-key-prod:latest,DB_PASSWORD=postgres-password-prod:latest \
-            curator-prod
+            --set-env-vars=DJANGO_SETTINGS_MODULE=${{ steps.deploy_info.outputs.django_settings_module }},DB_ENGINE=$DB_ENGINE,DB_HOST=/cloudsql/${{ steps.deploy_info.outputs.cloud_sql_id }},DB_DATABASE=${{ steps.deploy_info.outputs.db_database }},DB_USER=${{ steps.deploy_info.outputs.db_user }},ALLOWED_HOSTS=curator.populationgenomics.org.au,CURATION_PORTAL_AUTH_HEADER=HTTP_X_GOOG_AUTHENTICATED_USER_EMAIL \
+            --update-secrets=SECRET_KEY=django-secret-key-${{ steps.deploy_info.outputs.type }}:latest,DB_PASSWORD=postgres-password-${{ steps.deploy_info.outputs.type }}:latest

--- a/.github/workflows/deploy_prod.yaml
+++ b/.github/workflows/deploy_prod.yaml
@@ -34,17 +34,17 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-dev.txt
 
-      - name: "install Cloud SQL Proxy"
-        run: |
-          wget https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 -O cloud_sql_proxy
-          chmod +x cloud_sql_proxy
+      - name: "authenticate google cloud"
+        id: "auth"
+        uses: "google-github-actions/auth@v1"
+        with:
+          service_account: ${{ secrets.GCP_DEPLOY_KEY }}
 
       - name: "gcloud setup"
-        id: "auth"
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: curator-348003
-          service_account_key: ${{ secrets.GCP_DEPLOY_KEY }}
+          install_components: "cloud_sql_proxy"
 
       - name: "gcloud secrets"
         id: "secrets"
@@ -58,13 +58,16 @@ jobs:
         env:
           DJANGO_SETTINGS_MODULE: curation_portal.settings.base
           DB_ENGINE: django.db.backends.postgresql
-          DB_HOST: /cloudsql/curator-348003:australia-southeast1:curator-postgres
+          DB_HOST: localhost
+          DB_PORT: 5432
           DB_DATABASE: curator-prod
           DB_USER: curator-prod
           DB_PASSWORD: "${{ steps.secrets.outputs.db_password }}"
           SECRET_KEY: "${{ steps.secrets.outputs.secret_key }}"
         run: |
-          python manage.py migrate
+          ./cloud-sql-proxy \
+            --port 5432 curator-348003:australia-southeast1:curator-postgres &
+            python manage.py migrate
 
   deploy_server:
     runs-on: ubuntu-latest
@@ -78,11 +81,16 @@ jobs:
       - name: "checkout repo"
         uses: actions/checkout@v2
 
+      - name: "authenticate google cloud"
+        id: "auth"
+        uses: "google-github-actions/auth@v1"
+        with:
+          service_account: ${{ secrets.GCP_DEPLOY_KEY }}
+
       - name: "gcloud setup"
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: curator-348003
-          service_account_key: ${{ secrets.GCP_DEPLOY_KEY }}
 
       - name: "build and deploy"
         run: |

--- a/curation_portal/settings/dev.py
+++ b/curation_portal/settings/dev.py
@@ -1,0 +1,3 @@
+"""Django settings for dev deployment"""
+
+from .base import *  # pylint: disable=wildcard-import,unused-wildcard-import


### PR DESCRIPTION
Added a new job to workflow config `deploy_prod.yaml` that applies database migrations

Notable changes:
- Migrated `google-github-actions/setup-gcloud` to `@v1`
- Added the now required `google-github-actions/auth@v1` step to both jobs
- Execute database migration from [cloud sql proxy](https://github.com/GoogleCloudPlatform/cloud-sql-proxy) bound to localhost