### PR TITLE
Accept gene symbols

### DIFF
--- a/scripts/get_gnomad_lof_variants.py
+++ b/scripts/get_gnomad_lof_variants.py
@@ -270,7 +270,7 @@ if __name__ == "__main__":
         "--genes-file",
         help="Full GCP path to a txt file with one gene per line, in the format specified by --id-type (defaults to Ensembl ID)",
     )
-    group.add_argument(
+    parser.add_argument(
         "--id-type",
         choices=('ensembl','symbol'),
         default='ensembl',

--- a/scripts/get_gnomad_lof_variants.py
+++ b/scripts/get_gnomad_lof_variants.py
@@ -136,9 +136,16 @@ def get_gnomad_lof_variants(gnomad_version, gene_ids, include_low_confidence=Fal
     # using the GENCODE table directly.
     # Would need to provide the correct GENCODE GTF here for gnomAD v3.
     assert gnomad_version == 2
-    gene_intervals = hl.experimental.get_gene_intervals(
-        gene_ids=gene_ids, reference_genome=reference_genome
-    )
+
+    if(args.id_type == 'symbol'):
+        gene_intervals = hl.experimental.get_gene_intervals(
+            gene_symbols=gene_ids, reference_genome=reference_genome
+        )
+    else:    
+        gene_intervals = hl.experimental.get_gene_intervals(
+            gene_ids=gene_ids, reference_genome=reference_genome
+        )
+    
     ds = hl.filter_intervals(ds, gene_intervals)
 
     gene_ids = hl.set(gene_ids)
@@ -147,7 +154,7 @@ def get_gnomad_lof_variants(gnomad_version, gene_ids, include_low_confidence=Fal
     ds = ds.annotate(
         lof_consequences=ds.vep.transcript_consequences.filter(
             lambda csq: (
-                gene_ids.contains(csq.gene_id)
+                gene_ids.contains(csq.gene_symbol if args.id_type == "symbol" else csq.gene_id)
                 & csq.consequence_terms.any(lambda term: PLOF_CONSEQUENCE_TERMS.contains(term))
                 & (include_low_confidence | (csq.lof == "HC"))
             )
@@ -196,7 +203,7 @@ def get_gnomad_lof_variants(gnomad_version, gene_ids, include_low_confidence=Fal
         constraint = hl.read_table(GNOMAD_V2_CONSTRAINT)
 
         # Filter to our genes of interest.
-        constraint = constraint.filter(gene_ids.contains(constraint.gene_id))
+        constraint = constraint.filter(gene_ids.contains(constraint.gene if args.id_type == "symbol" else constraint.gene_id))
         constraint = constraint.repartition(10)
 
         # Convert the constraint table to a lookup dictionary, so that map can handle it.
@@ -254,14 +261,20 @@ if __name__ == "__main__":
         "--gene-ids",
         nargs="+",
         metavar="GENE",
-        help="Ensembl IDs of genes")
+        help="The gene(s) to process, in the format specified by --id-type (defaults to Ensembl ID)")
     group.add_argument(
         "--genes-table",
         help="relative dataset path (analysis category) to a Hail table with a gene_id field containing Ensembl IDs",
     )
     group.add_argument(
         "--genes-file",
-        help="Full GCP path to a txt file with one Ensembl gene ID per line",
+        help="Full GCP path to a txt file with one gene per line, in the format specified by --id-type (defaults to Ensembl ID)",
+    )
+    group.add_argument(
+        "--id-type",
+        choices=('ensembl','symbol'),
+        default='ensembl',
+        help="The type of gene ID provided; must be one of 'ensembl' or 'symbol'"
     )
     parser.add_argument(
         "--gnomad-version",
@@ -301,10 +314,11 @@ if __name__ == "__main__":
         genes = args.gene_ids
     elif args.genes_file:
         with AnyPath(args.genes_file).open('r') as f:
-            genes = [line.strip() for line in f if line.strip()]
+            genes = [line.strip().split(',', 1)[0].split(None, 1)[0] for line in f if line.strip()]
     else:
         genes_table = hl.read_table(dataset_path(args.genes_table, "analysis"))
         genes = list(set(genes_table.gene_id.collect()))
+        args.id_type='ensembl'
 
     # Fetch the (optionally filtered and annotated) pLoF variants from the appropriate gnomAD dataset.
     variants = get_gnomad_lof_variants(


### PR DESCRIPTION
Adjust the get_gnomad_log_variants.py to allow it to accept either Ensembl IDs or gene symbols as input (except when an existing hail table is used to provide the gene_ids). Default is to expect Ensembl IDs, unless --id-type 'symbol' is passed.