### PR TITLE
Remove redundant branch to deploy input option

### DIFF
--- a/.github/workflows/deploy_prod.yaml
+++ b/.github/workflows/deploy_prod.yaml
@@ -2,11 +2,6 @@ name: Deploy
 
 on:
   workflow_dispatch:
-    inputs:
-      branch:
-        description: "Branch to deploy"
-        required: true
-        default: "main"
   push:
     branches:
       - main


### PR DESCRIPTION
The `workflow_dispatch` already comes with a branch selection option, another is not needed