### PR TITLE
Add NULL coalescing for Allelic Depth field rendering in react

### DIFF
--- a/assets/components/pages/project/curate/VariantData.js
+++ b/assets/components/pages/project/curate/VariantData.js
@@ -187,9 +187,7 @@ class VariantData extends React.Component {
         </List.Item>
         <List.Item>
           <strong>Allelic Depths:</strong>{" "}
-          {variant.AD
-            ? variant.AD.map((depths) => `(${depths.join(", ")})`).join(", ")
-            : "N/A"}
+          {variant.AD ? variant.AD.map((depths) => `(${depths.join(", ")})`).join(", ") : "N/A"}
         </List.Item>
         <List.Item>
           <strong>Read Depths (all ALT genotypes):</strong> {(variant.DP_all ?? []).join(", ")}

--- a/assets/components/pages/project/curate/VariantData.js
+++ b/assets/components/pages/project/curate/VariantData.js
@@ -187,7 +187,9 @@ class VariantData extends React.Component {
         </List.Item>
         <List.Item>
           <strong>Allelic Depths:</strong>{" "}
-          {variant.AD.map((depths) => `(${depths.join(", ")})`).join(", ")}
+          {variant.AD
+            ? variant.AD.map((depths) => `(${depths.join(", ")})`).join(", ")
+            : "N/A"}
         </List.Item>
         <List.Item>
           <strong>Read Depths (all ALT genotypes):</strong> {(variant.DP_all ?? []).join(", ")}
@@ -197,7 +199,9 @@ class VariantData extends React.Component {
         </List.Item>
         <List.Item>
           <strong>Allelic Depths (all ALT genotypes):</strong>{" "}
-          {variant.AD_all.map((depths) => `(${depths.join(", ")})`).join(", ")}
+          {variant.AD_all
+            ? variant.AD_all.map((depths) => `(${depths.join(", ")})`).join(", ")
+            : "N/A"}
         </List.Item>
         <List.Item>
           <strong>Number of homozygotes:</strong> {variant.n_homozygotes}


### PR DESCRIPTION
Minor fix to handle `NULL` values in the `AD` and `AD_all` fields, otherwise the Variant Curation page will not load for the older, existing variants where these fields are `NULL`.