### PR TITLE
Set gunicorn workers and threads to values suggested by documentation

### DIFF
--- a/.github/workflows/deploy_prod.yaml
+++ b/.github/workflows/deploy_prod.yaml
@@ -109,6 +109,5 @@ jobs:
             --add-cloudsql-instances=${{ steps.deploy_info.outputs.cloud_sql_id }} \
             --image=${{ steps.deploy_info.outputs.image_tag }} \
             --port=8000 \
-            --memory=1024Mi \
             --set-env-vars=DJANGO_SETTINGS_MODULE=${{ steps.deploy_info.outputs.django_settings_module }},DB_ENGINE=$DB_ENGINE,DB_HOST=/cloudsql/${{ steps.deploy_info.outputs.cloud_sql_id }},DB_DATABASE=${{ steps.deploy_info.outputs.db_database }},DB_USER=${{ steps.deploy_info.outputs.db_user }},ALLOWED_HOSTS=curator.populationgenomics.org.au,CURATION_PORTAL_AUTH_HEADER=HTTP_X_GOOG_AUTHENTICATED_USER_EMAIL \
             --update-secrets=SECRET_KEY=django-secret-key-${{ steps.deploy_info.outputs.type }}:latest,DB_PASSWORD=postgres-password-${{ steps.deploy_info.outputs.type }}:latest

--- a/.github/workflows/deploy_prod.yaml
+++ b/.github/workflows/deploy_prod.yaml
@@ -109,5 +109,6 @@ jobs:
             --add-cloudsql-instances=${{ steps.deploy_info.outputs.cloud_sql_id }} \
             --image=${{ steps.deploy_info.outputs.image_tag }} \
             --port=8000 \
+            --memory=1024Mi \
             --set-env-vars=DJANGO_SETTINGS_MODULE=${{ steps.deploy_info.outputs.django_settings_module }},DB_ENGINE=$DB_ENGINE,DB_HOST=/cloudsql/${{ steps.deploy_info.outputs.cloud_sql_id }},DB_DATABASE=${{ steps.deploy_info.outputs.db_database }},DB_USER=${{ steps.deploy_info.outputs.db_user }},ALLOWED_HOSTS=curator.populationgenomics.org.au,CURATION_PORTAL_AUTH_HEADER=HTTP_X_GOOG_AUTHENTICATED_USER_EMAIL \
             --update-secrets=SECRET_KEY=django-secret-key-${{ steps.deploy_info.outputs.type }}:latest,DB_PASSWORD=postgres-password-${{ steps.deploy_info.outputs.type }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,6 @@ USER app
 CMD ["gunicorn", \
   "--bind", ":8000", \
   "--log-file", "-", \
-  "--workers", "2", "--threads", "4", "--worker-class", "gthread", \
+  "--workers", "3", "--threads", "1", "--worker-class", "gthread", \
   "--worker-tmp-dir", "/dev/shm", \
   "curation_portal.wsgi"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,8 @@ RUN chown -R app:app .
 USER app
 
 # Run
+# Worker and thread count set according to gunicorn docs
+# https://docs.gunicorn.org/en/stable/design.html#how-many-workers
 CMD ["gunicorn", \
   "--bind", ":8000", \
   "--log-file", "-", \


### PR DESCRIPTION
The current deployed cloudrun instance for the curation portal only has 512Mi of memory. As the number of variants in the project scales, the curators are facing long delays in loading projects, variants, charts, etc. ~Doubling the memory with the [--memory flag](https://cloud.google.com/sdk/gcloud/reference/run/deploy#--memory) may alleviate some of these issues.~

As suggested below by Michael, more memory may not be the solution. We should start by correcting the number of workers `=(2x threads) + 1` and threads `=1` (as gcloud is not hyperthreaded) and see if there is a noticeable improvement.