### PR TITLE
Environment Lock

### DIFF
--- a/.github/workflows/deploy_prod.yaml
+++ b/.github/workflows/deploy_prod.yaml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
-
+    environment: production
     env:
       DOCKER_BUILDKIT: 1
       BUILDKIT_PROGRESS: plain


### PR DESCRIPTION
## Description
In a bid to introduce better security permissions, we have replaced the use of SA keys to workload identity providers where possible. We will also ensure the workload federated identities are attached to an environment in the repo. 

## Changes
- [x]  Added `environment` attribute to the `deploy` workflow