### PR TITLE
Update project_results to use prefetch_related call

### DIFF
--- a/curation_portal/views/project_results.py
+++ b/curation_portal/views/project_results.py
@@ -85,7 +85,7 @@ class ProjectResultsView(APIView):
 
         results = CurationResult.objects.filter(
             assignment__variant__project=project
-        ).select_related("assignment__curator", "assignment__variant")
+        ).prefetch_related("assignment__curator", "assignment__variant")
         serializer = CurationResultSerializer(results, many=True)
         return Response({"results": serializer.data})
 


### PR DESCRIPTION
The projects results page is taking 30-60 seconds to load on average for projects with 1000+ variants. This small change to the API call will mean python to handles the joins (as opposed to the DB handling the joins) which may be cheaper and quicker to execute. 

`select_related` and `prefetch_related` both have the same effect, so we can be confident that this change won't break anything. But it's not clear if we'll see a speedup until we can look at a project with a tonne of variant results - like some projects in production. 

Following this PR and some local testing I'll open another one to merge these changes into main so they can be deployed in production and we can see if some speedup is achieved.