### PR TITLE
Update project_results to use prefetch_related call (#67)

### DIFF
--- a/curation_portal/views/project_results.py
+++ b/curation_portal/views/project_results.py
@@ -85,7 +85,7 @@ class ProjectResultsView(APIView):
 
         results = CurationResult.objects.filter(
             assignment__variant__project=project
-        ).select_related("assignment__curator", "assignment__variant")
+        ).prefetch_related("assignment__curator", "assignment__variant")
         serializer = CurationResultSerializer(results, many=True)
         return Response({"results": serializer.data})
 


### PR DESCRIPTION
Merges in the change from https://github.com/populationgenomics/variant-curation-portal/pull/67

Change has been tested locally and there doesn't seem to be any difference with the project results page display. Keen to see this change in production to see if we get a speedup in displaying results. 