### PR TITLE
Update project results export with better prefetching

### DIFF
--- a/curation_portal/serializers.py
+++ b/curation_portal/serializers.py
@@ -219,7 +219,7 @@ class CustomFlagSerializer(ModelSerializer):
 
 class CustomFlagCurationResultSerializer(DictField):
     custom_flags = CustomFlag.objects.all()
-    
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.error_messages[

--- a/curation_portal/serializers.py
+++ b/curation_portal/serializers.py
@@ -218,6 +218,8 @@ class CustomFlagSerializer(ModelSerializer):
 
 
 class CustomFlagCurationResultSerializer(DictField):
+    custom_flags = CustomFlag.objects.all()
+    
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.error_messages[
@@ -227,23 +229,22 @@ class CustomFlagCurationResultSerializer(DictField):
     def get_default(self):
         default = super().get_default()
         if not default:
-            return {f.key: False for f in CustomFlag.objects.all()}
+            return {f.key: False for f in self.custom_flags}
         return default
 
     def get_initial(self):
         initial = super().get_initial()
         if not initial:
-            return {f.key: False for f in CustomFlag.objects.all()}
+            return {f.key: False for f in self.custom_flags}
         return initial
 
     def to_representation(self, value):
         flags_related_to_curation_result = getattr(value, "all", lambda: [])()
         flags = {c.flag.key: c.checked for c in flags_related_to_curation_result}
 
-        for flag in CustomFlag.objects.all():
+        for flag in self.custom_flags:
             if flag.key not in flags:
                 flags[flag.key] = False
-
         return flags
 
     def create(self, result, data):

--- a/curation_portal/views/project_results_export.py
+++ b/curation_portal/views/project_results_export.py
@@ -111,6 +111,7 @@ class ExportProjectResultsView(APIView):
         )
         serializer = ExportedResultSerializer(
             instance=curation_results,
+            # instance=CurationResult.objects.filter(assignment__in=filtered_assignments_qs),
             many=True,
             context={"project": project},
         )
@@ -137,7 +138,7 @@ class ExportProjectResultsView(APIView):
         writer.writerow(header_row)
 
         for assignment in filtered_assignments_qs:
-            variant_annotations = assignment.variant.annotations.all()
+            editor = assignment.result.editor
             custom_flag_results = {flag.flag.key: flag.checked for flag in assignment.result.custom_flags.all()}
             
             row = (
@@ -146,17 +147,17 @@ class ExportProjectResultsView(APIView):
                     ";".join(
                         set(
                             f"{annotation.gene_id}:{annotation.gene_symbol}"
-                            for annotation in variant_annotations
+                            for annotation in assignment.variant.annotations.all()
                         )
                     ),
                     ";".join(
                         set(
                             annotation.transcript_id
-                            for annotation in variant_annotations
+                            for annotation in assignment.variant.annotations.all()
                         )
                     ),
                     assignment.curator.username,
-                    assignment.result.editor.username if assignment.result.editor else None,
+                    editor.username if editor else None,
                 ]
                 + [getattr(assignment.result, f) for f in result_fields]
                 # Custom flag results

--- a/curation_portal/views/project_results_export.py
+++ b/curation_portal/views/project_results_export.py
@@ -111,7 +111,6 @@ class ExportProjectResultsView(APIView):
         )
         serializer = ExportedResultSerializer(
             instance=curation_results,
-            # instance=CurationResult.objects.filter(assignment__in=filtered_assignments_qs),
             many=True,
             context={"project": project},
         )

--- a/curation_portal/views/project_results_export.py
+++ b/curation_portal/views/project_results_export.py
@@ -103,7 +103,9 @@ class ExportProjectResultsView(APIView):
         response["Content-Disposition"] = f'attachment; filename="{filename_prefix}_results.json"'
 
         project = self.get_project()
-        curation_results = CurationResult.objects.filter(assignment__in=filtered_assignments_qs).prefetch_related(
+        curation_results = CurationResult.objects.filter(
+            assignment__in=filtered_assignments_qs
+        ).prefetch_related(
             Prefetch(
                 "custom_flags",
                 queryset=CustomFlagCurationResult.objects.select_related("flag"),
@@ -138,8 +140,10 @@ class ExportProjectResultsView(APIView):
 
         for assignment in filtered_assignments_qs:
             editor = assignment.result.editor
-            custom_flag_results = {flag.flag.key: flag.checked for flag in assignment.result.custom_flags.all()}
-            
+            custom_flag_results = {
+                flag.flag.key: flag.checked for flag in assignment.result.custom_flags.all()
+            }
+
             row = (
                 [
                     assignment.variant.variant_id,
@@ -160,9 +164,7 @@ class ExportProjectResultsView(APIView):
                 ]
                 + [getattr(assignment.result, f) for f in result_fields]
                 # Custom flag results
-                + [
-                    custom_flag_results.get(flag.key, False) for flag in custom_flags
-                ]
+                + [custom_flag_results.get(flag.key, False) for flag in custom_flags]
             )
             writer.writerow(row)
 


### PR DESCRIPTION
This PR improves the result fetching when exporting results as JSON and CSV. Resolves https://github.com/populationgenomics/variant-curation-portal/issues/71.

- Some tweaks to the `CustomFlagCurationResultSerializer` mean that the list of `CustomFlag.objects.all()` is defined at the top of the serializer so it can be accessed in a nicer way with `self.custom_flags`.

- In the `ExportProjectResultsView` API view, prefetch the related custom flags and users for each CurationResult in the filtered CurationAssignment queryset. The queryset with prefetching can then be passed to the `get_json_response` and `get_csv_response` functions to reduce the number of queries executed and the time taken to fetch the results.

Exporting results using either of these methods is vastly improved, however the CSV export seems much more optimized than the JSON export.

--- 

### JSON export
**For a project with 200 results**
- Runtime: ~20s -> 4s
- Number of Queries: ~2500 -> 600

In `get_json_response`, we prefetch all custom flags relating to the CurationResults that are in the assignments queryset. This improves the response time by eliminating all repetitive queries of the form:
```
SELECT "custom_flag"."id", "custom_flag"."created_at", "custom_flag"."updated_at", "custom_flag"."key", "custom_flag"."label", "custom_flag"."shortcut" FROM "custom_flag" WHERE "custom_flag"."id" = 1; args=(1,)
SELECT "custom_flag"."id", "custom_flag"."created_at", "custom_flag"."updated_at", "custom_flag"."key", "custom_flag"."label", "custom_flag"."shortcut" FROM "custom_flag" WHERE "custom_flag"."id" = 2; args=(2,)
...
SELECT "custom_flag"."id", "custom_flag"."created_at", "custom_flag"."updated_at", "custom_flag"."key", "custom_flag"."label", "custom_flag"."shortcut" FROM "custom_flag" WHERE "custom_flag"."id" = 8; args=(8,)
```

There are still a lot of repetitive queries like:
```
SELECT ••• FROM "curation_portal_user" WHERE "curation_portal_user"."id" = 1
 200 similar queries.  Duplicated 200 times.
```

I tried a few ways to prefetch the user IDs but none really had any impact on reducing these queries.

### CSV Export
**For a project with 200 results**
- Runtime: ~20s -> 0.2ms
- Number of Queries: ~2500 -> 8

In `get_csv_response`, the improvement is much more significant. We define the custom_flag_results as a dict for each assignment, rather than calling `getattr` to check each flag result for each assignment in the list comprehension.
These are the queries that get run:
```SQL
SELECT ••• FROM "curation_project" WHERE "curation_project"."id" = 1 
SELECT ••• FROM "curation_portal_user" INNER JOIN "curation_project_owners" ON ("curation_portal_user"."id" = "curation_project_owners"."user_id") WHERE ("curation_project_owners"."project_id" = 1 AND "curation_portal_user"."id" = 1) LIMIT 1
SELECT ••• FROM "curation_portal_user" INNER JOIN "curation_project_owners" ON ("curation_portal_user"."id" = "curation_project_owners"."user_id") WHERE ("curation_project_owners"."project_id" = 1 AND "curation_portal_user"."id" = 1) LIMIT 1
SELECT ••• FROM "custom_flag"
SELECT ••• FROM "curation_assignment" INNER JOIN "curation_result" ON ("curation_assignment"."result_id" = "curation_result"."id") INNER JOIN "curation_variant" ON ("curation_assignment"."variant_id" = "curation_variant"."id") INNER JOIN "curation_portal_user" ON ("curation_assignment"."curator_id" = "curation_portal_user"."id") WHERE ("curation_result"."verdict" IS NOT NULL AND "curation_variant"."project_id" = 1 AND "curation_portal_user"."username" = ...)
SELECT ••• FROM "curation_variant_annotation" WHERE "curation_variant_annotation"."variant_id" IN (...)
SELECT ••• FROM "custom_flag_curation_result" INNER JOIN "custom_flag" ON ("custom_flag_curation_result"."flag_id" = "custom_flag"."id") WHERE "custom_flag_curation_result"."result_id" IN (...)
SELECT ••• FROM "curation_portal_user" WHERE "curation_portal_user"."id" IN (NULL)
```