### PR TITLE
Hotfix gnomad lof script - Add ref genome arg to liftover fn call

### DIFF
--- a/scripts/get_gnomad_lof_variants.py
+++ b/scripts/get_gnomad_lof_variants.py
@@ -232,7 +232,7 @@ def get_gnomad_lof_variants(
     ds = ds.filter((hl.len(ds.exome.filters) == 0) | (hl.len(ds.genome.filters) == 0))
 
     # Add the liftover mapping to hg37 or hg38 from the gnomAD liftover tables
-    ds = add_liftover_mapping(ds)
+    ds = add_liftover_mapping(ds, reference_genome)
 
     # Format for the LoF curation portal.
     ds = ds.select(


### PR DESCRIPTION
Quick fix to add in the reference genome argument required by this function, the script can't run without it.

See the error here:
https://batch.hail.populationgenomics.org.au/batches/530065/jobs/1