### PR TITLE
Use hl.is_missing for existence checks, not bare python

### DIFF
--- a/scripts/get_gnomad_lof_variants.py
+++ b/scripts/get_gnomad_lof_variants.py
@@ -167,7 +167,7 @@ def add_liftover_mapping(ds, reference_genome, sequencing_type='genome'):
 
 
 def variant_id(locus, alleles):
-    if not locus or not alleles:
+    if hl.is_missing(locus) or hl.is_missing(alleles):
         return hl.missing(hl.tstr)
     return (
         locus.contig.replace("^chr", "")


### PR DESCRIPTION
Hotfixes the script to use hl.is_missing to check the hail table fields existence, rather than python boolean checks, since hail expressions can't be checked like that.

See the failure here:
https://batch.hail.populationgenomics.org.au/batches/530074/jobs/1