### PR TITLE
Use hl.if_else to format the variant id string

### DIFF
--- a/scripts/get_gnomad_lof_variants.py
+++ b/scripts/get_gnomad_lof_variants.py
@@ -167,16 +167,21 @@ def add_liftover_mapping(ds, reference_genome, sequencing_type='genome'):
 
 
 def variant_id(locus, alleles):
-    if hl.is_missing(locus) or hl.is_missing(alleles):
-        return hl.missing(hl.tstr)
-    return (
-        locus.contig.replace("^chr", "")
-        + "-"
-        + hl.str(locus.position)
-        + "-"
-        + alleles[0]
-        + "-"
-        + alleles[1]
+    """Format a variant ID string from a locus and alleles."""
+    return hl.eval(
+        hl.if_else(
+            hl.is_missing(locus) | hl.is_missing(alleles), 
+            hl.missing(hl.tstr), 
+            (
+                locus.contig.replace("^chr", "")
+                + "-"
+                + hl.str(locus.position)
+                + "-"
+                + alleles[0]
+                + "-"
+                + alleles[1]
+            )
+        )
     )
 
 


### PR DESCRIPTION
Hail is still not happy with checking if the `hl.is_missing(field)` values are boolean, so we will wrap this whole block in a hail `if_else` statement.

If the locus or alleles value is missing, return a hail missing string object. If they are present, format them as the variant ID.

See the failure here:
https://batch.hail.populationgenomics.org.au/batches/530077/jobs/1