### PR TITLE
Remove hl.eval from the hl.if_else varid formatting

### DIFF
--- a/scripts/get_gnomad_lof_variants.py
+++ b/scripts/get_gnomad_lof_variants.py
@@ -5,9 +5,9 @@ from cloudpathlib import AnyPath
 
 import hail as hl
 import pandas as pd
-import requests
 
-from cpg_utils.hail_batch import init_batch, dataset_path, output_path
+from cpg_utils.hail_batch import init_batch, dataset_path
+from cpg_utils.config import output_path
 
 CONSEQUENCE_TERMS = [
     "transcript_ablation",

--- a/scripts/get_gnomad_lof_variants.py
+++ b/scripts/get_gnomad_lof_variants.py
@@ -168,19 +168,17 @@ def add_liftover_mapping(ds, reference_genome, sequencing_type='genome'):
 
 def variant_id(locus, alleles):
     """Format a variant ID string from a locus and alleles."""
-    return hl.eval(
-        hl.if_else(
-            hl.is_missing(locus) | hl.is_missing(alleles), 
-            hl.missing(hl.tstr), 
-            (
-                locus.contig.replace("^chr", "")
-                + "-"
-                + hl.str(locus.position)
-                + "-"
-                + alleles[0]
-                + "-"
-                + alleles[1]
-            )
+    return hl.if_else(
+        hl.is_missing(locus) | hl.is_missing(alleles), 
+        hl.missing(hl.tstr), 
+        (
+            locus.contig.replace("^chr", "")
+            + "-"
+            + hl.str(locus.position)
+            + "-"
+            + alleles[0]
+            + "-"
+            + alleles[1]
         )
     )
 


### PR DESCRIPTION
Need to remove the `hl.eval` from this `hl.if_else` which formats the Variant ID row. This is because we don't want to evaluate the result, seeing as the result is being passed to another hail object, it does not need to be evaluated to get there.

See the failure:
https://batch.hail.populationgenomics.org.au/batches/530086/jobs/1