### PR TITLE
Add new igv js track defaults - colorBy strand, showSoftClips

### DIFF
--- a/assets/components/IGVComponent.js
+++ b/assets/components/IGVComponent.js
@@ -37,6 +37,8 @@ const createTracks = ({ reads, endpoint }) => {
     return {
       name: sampleId,
       sourceType: "file",
+      colorBy: "strand",
+      showSoftClips: true,
       url: `${endpoint}/?file=${encodeURIComponent(read)}`.replace("//", "/"),
       indexURL: `${endpoint}/?file=${encodeURIComponent(indexURL)}`.replace("//", "/"),
       format: ext,


### PR DESCRIPTION
This PR sets new defaults for the IGV js instance implemented in the variant curation portal.

Since only `alignment` tracks (BAMs/CRAMs) are used by the portal, we can set track configuration options based on the documentation [here](https://igv.org/doc/igvjs/#tracks/Alignment-Track/#configuration-options).

As suggested by the curation team [here](https://centrepopgen.slack.com/archives/C046XUS8DGT/p1736130309002619) (thanks @SamBryen), helpful defaults should include showing soft clipped reads, and colouring the reads by strand orientation. 