### PR TITLE
GnomAD v4 links to replace GnomAD v3 links in Variant Curation iframe quicklinks

### DIFF
--- a/assets/components/pages/project/curate/CurateVariantPage.js
+++ b/assets/components/pages/project/curate/CurateVariantPage.js
@@ -222,7 +222,7 @@ class CurateVariantPage extends React.Component {
                         </List.Item>
                         <List.Item>
                           <a href="#gnomad-variant">
-                            gnomAD v{variant.reference_genome === "GRCh37" ? "2" : "3"} (variant)
+                            gnomAD v{variant.reference_genome === "GRCh37" ? "2" : "4"} (variant)
                           </a>
                         </List.Item>
                         {variant.reference_genome === "GRCh37" ? (
@@ -237,9 +237,9 @@ class CurateVariantPage extends React.Component {
                           <>
                             <List.Item>
                               {hasAnnotations ? (
-                                <a href="#gnomad-v3-gene">gnomAD v3 (gene)</a>
+                                <a href="#gnomad-v4-gene">gnomAD v4 (gene)</a>
                               ) : (
-                                "gnomAD v3 (gene)"
+                                "gnomAD v4 (gene)"
                               )}
                             </List.Item>
                             <List.Item>
@@ -375,7 +375,7 @@ class CurateVariantPage extends React.Component {
                 </div>
                 <div id="gnomad-variant">
                   <GnomadVariantView
-                    gnomadVersion={variant.reference_genome === "GRCh37" ? "2" : "3"}
+                    gnomadVersion={variant.reference_genome === "GRCh37" ? "2" : "4"}
                     variant={variant}
                   />
                 </div>
@@ -383,14 +383,14 @@ class CurateVariantPage extends React.Component {
                 {variant.reference_genome === "GRCh37" ? (
                   <div id="gnomad-v2-gene">
                     <GnomadGeneView
-                      gnomadVersion={variant.reference_genome === "GRCh37" ? "2" : "3"}
+                      gnomadVersion={variant.reference_genome === "GRCh37" ? "2" : "4"}
                       variant={variant}
                     />
                   </div>
                 ) : (
                   <>
-                    <div id="gnomad-v3-gene">
-                      <GnomadGeneView gnomadVersion="3" variant={variant} />
+                    <div id="gnomad-v4-gene">
+                      <GnomadGeneView gnomadVersion="4" variant={variant} />
                     </div>
                     <br />
                     <div id="gnomad-v2-gene">

--- a/assets/components/pages/project/curate/gnomad.js
+++ b/assets/components/pages/project/curate/gnomad.js
@@ -5,19 +5,19 @@ import { Header, Segment } from "semantic-ui-react";
 export const GnomadVariantView = ({ gnomadVersion, variant }) => {
   const gnomadDataset = {
     2: "gnomad_r2_1",
-    3: "gnomad_r3",
+    4: "gnomad_r4",
   }[gnomadVersion];
 
   let gnomadVariantId;
   if (variant.reference_genome === "GRCh37") {
     gnomadVariantId = {
       2: variant.variant_id,
-      3: variant.liftover_variant_id,
+      4: variant.liftover_variant_id,
     }[gnomadVersion];
   } else if (variant.reference_genome === "GRCh38") {
     gnomadVariantId = {
       2: variant.liftover_variant_id,
-      3: variant.variant_id,
+      4: variant.variant_id,
     }[gnomadVersion];
   }
 
@@ -50,7 +50,7 @@ export const GnomadVariantView = ({ gnomadVersion, variant }) => {
 };
 
 GnomadVariantView.propTypes = {
-  gnomadVersion: PropTypes.oneOf(["2", "3"]).isRequired,
+  gnomadVersion: PropTypes.oneOf(["2", "4"]).isRequired,
   variant: PropTypes.shape({
     reference_genome: PropTypes.oneOf(["GRCh37", "GRCh38"]).isRequired,
     variant_id: PropTypes.string.isRequired,
@@ -79,7 +79,7 @@ export const GnomadGeneView = ({ gnomadVersion, variant }) => {
 
   const gnomadDataset = {
     2: "gnomad_r2_1",
-    3: "gnomad_r3",
+    4: "gnomad_r4",
   }[gnomadVersion];
 
   const url = `https://gnomad.broadinstitute.org/gene/${annotations[0].gene_id}?dataset=${gnomadDataset}`;
@@ -97,7 +97,7 @@ export const GnomadGeneView = ({ gnomadVersion, variant }) => {
 };
 
 GnomadGeneView.propTypes = {
-  gnomadVersion: PropTypes.oneOf(["2", "3"]).isRequired,
+  gnomadVersion: PropTypes.oneOf(["2", "4"]).isRequired,
   variant: PropTypes.shape({
     annotations: PropTypes.arrayOf(
       PropTypes.shape({


### PR DESCRIPTION
Updates the GnomAD links in the variant curation page to use the URL suffix `?dataset=gnomad_r4` instead of `?dataset=gnomad_r3`, which will allow curators to go straight to the v4 GnomAD variant/gene pages without extra clicks. 